### PR TITLE
fix function new_AsteriskManager in phpagi class

### DIFF
--- a/phpagi-asmanager.php
+++ b/phpagi-asmanager.php
@@ -78,7 +78,7 @@
     * @access private
     * @var AGI
     */
-    private $pagi;
+    public $pagi = false;
 
    /**
     * Event Handlers

--- a/phpagi.php
+++ b/phpagi.php
@@ -1551,7 +1551,7 @@ class AGI
     {
         $this->asm = new AGI_AsteriskManager(NULL, $this->config['asmanager']);
         $this->asm->pagi =& $this;
-        $this->config['asmanager'] =& $this->asm->config;
+        $this->config['asmanager'] =& $this->asm->config['asmanager'];
         return $this->asm;
     }
 

--- a/phpagi.php
+++ b/phpagi.php
@@ -1549,9 +1549,9 @@ class AGI
     */
     function &new_AsteriskManager()
     {
-        $this->asm = new AGI_AsteriskManager(NULL, $this->config);
+        $this->asm = new AGI_AsteriskManager(NULL, $this->config['asmanager']);
         $this->asm->pagi =& $this;
-        $this->config =& $this->asm->config;
+        $this->config['asmanager'] =& $this->asm->config;
         return $this->asm;
     }
 


### PR DESCRIPTION
The asmanager configuration is stored in $this->config['asmanager'] array of AGI class not in $this->config root.
And property pagi of AGI_AsteriskManager must be public to permit the assignement of AGI instance