### PR TITLE
Hotfix which function

### DIFF
--- a/phpagi-asmanager.php
+++ b/phpagi-asmanager.php
@@ -78,7 +78,7 @@
     * @access private
     * @var AGI
     */
-    private $pagi;
+    public $pagi = false;
 
    /**
     * Event Handlers

--- a/phpagi.php
+++ b/phpagi.php
@@ -1551,7 +1551,7 @@ class AGI
     {
         $this->asm = new AGI_AsteriskManager(NULL, $this->config['asmanager']);
         $this->asm->pagi =& $this;
-        $this->config['asmanager'] =& $this->asm->config;
+        $this->config['asmanager'] =& $this->asm->config['asmanager'];
         return $this->asm;
     }
 

--- a/phpagi.php
+++ b/phpagi.php
@@ -1693,7 +1693,7 @@ class AGI
 
         if (is_null($checkpath)) {
             if (isset($_ENV['PATH'])) {
-                $chpath = $checkpath;
+                $chpath = $_ENV['PATH'];
             } else {
                 $chpath = '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:'.
                     '/usr/X11R6/bin:/usr/local/apache/bin:/usr/local/mysql/bin';

--- a/phpagi.php
+++ b/phpagi.php
@@ -1690,15 +1690,22 @@ class AGI
     function which($cmd, $checkpath=NULL)
     {
         global $_ENV;
-        $chpath = is_null($checkpath) ? $_ENV['PATH'] : $checkpath;
+
+        if (is_null($checkpath)) {
+            if (isset($_ENV['PATH'])) {
+                $chpath = $checkpath;
+            } else {
+                $chpath = '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:'.
+                    '/usr/X11R6/bin:/usr/local/apache/bin:/usr/local/mysql/bin';
+            }
+        } else {
+            $chpath = $checkpath;
+        }
 
         foreach(explode(':', $chpath) as $path)
           if(is_executable("$path/$cmd"))
             return "$path/$cmd";
 
-        if(is_null($checkpath))
-          return $this->which($cmd, '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:'.
-                                            '/usr/X11R6/bin:/usr/local/apache/bin:/usr/local/mysql/bin');
         return false;
     }
 

--- a/phpagi.php
+++ b/phpagi.php
@@ -1549,9 +1549,9 @@ class AGI
     */
     function &new_AsteriskManager()
     {
-        $this->asm = new AGI_AsteriskManager(NULL, $this->config);
+        $this->asm = new AGI_AsteriskManager(NULL, $this->config['asmanager']);
         $this->asm->pagi =& $this;
-        $this->config =& $this->asm->config;
+        $this->config['asmanager'] =& $this->asm->config;
         return $this->asm;
     }
 


### PR DESCRIPTION
when in php.ini the variables_order is not set to "EGPCS" (i.e. "GPCS" for production), the global $_ENV is not set and the function go into an error.